### PR TITLE
feat: add admin resource management and unified search

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -1,0 +1,6 @@
+{
+  "announcements": [],
+  "documents": [],
+  "links": [],
+  "auditLog": []
+}

--- a/src/app/(admin)/announcements/page.tsx
+++ b/src/app/(admin)/announcements/page.tsx
@@ -1,0 +1,230 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { getAdminActor, requireAdminSession } from '@/lib/auth/admin';
+import { formatDepartments, parseDepartmentInput } from '@/lib/access-control';
+import {
+  createAnnouncement,
+  deleteAnnouncement,
+  listAnnouncements,
+  updateAnnouncement,
+} from '@/lib/persistence/resources';
+
+const PAGE_PATH = '/announcements';
+
+async function createAnnouncementAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const title = (formData.get('title') as string | null)?.trim() ?? '';
+  const body = (formData.get('body') as string | null)?.trim() ?? '';
+  const category = (formData.get('category') as string | null)?.trim() ?? '';
+  const departmentsInput = (formData.get('departments') as string | null) ?? '';
+  if (!title || !body) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+
+  await createAnnouncement(
+    {
+      title,
+      body,
+      category: category || 'general',
+      departments: parseDepartmentInput(departmentsInput),
+    },
+    actor
+  );
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=created');
+}
+
+async function updateAnnouncementAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const id = (formData.get('id') as string | null)?.trim();
+  if (!id) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+  const title = (formData.get('title') as string | null)?.trim();
+  const body = (formData.get('body') as string | null)?.trim();
+  const category = (formData.get('category') as string | null)?.trim();
+  const departmentsInput = (formData.get('departments') as string | null) ?? '';
+
+  await updateAnnouncement(
+    id,
+    {
+      title: title ?? undefined,
+      body: body ?? undefined,
+      category: category ?? undefined,
+      departments: parseDepartmentInput(departmentsInput),
+    },
+    actor
+  );
+
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=updated');
+}
+
+async function deleteAnnouncementAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const id = (formData.get('id') as string | null)?.trim();
+  if (!id) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+  await deleteAnnouncement(id, actor);
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=deleted');
+}
+
+export default async function AnnouncementsAdminPage() {
+  const session = await requireAdminSession();
+  const announcements = await listAnnouncements();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-10 space-y-8">
+        <header className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            {session.user?.email ?? 'admin'}
+          </p>
+          <h1 className="text-3xl font-semibold">Announcements</h1>
+          <p className="text-muted-foreground">
+            Publish news to the portal and control visibility by department.
+          </p>
+        </header>
+
+        <section className="bg-card rounded-lg border p-6 space-y-4">
+          <h2 className="text-xl font-semibold">Create Announcement</h2>
+          <form action={createAnnouncementAction} className="space-y-4">
+            <div className="grid md:grid-cols-2 gap-4">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Title</span>
+                <input
+                  name="title"
+                  required
+                  className="border rounded-md px-3 py-2"
+                  placeholder="Quarterly update"
+                />
+              </label>
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Category</span>
+                <input
+                  name="category"
+                  className="border rounded-md px-3 py-2"
+                  placeholder="general"
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Body</span>
+              <textarea
+                name="body"
+                required
+                className="border rounded-md px-3 py-2 min-h-[120px]"
+                placeholder="Add the announcement details"
+              />
+            </label>
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Departments</span>
+              <input
+                name="departments"
+                className="border rounded-md px-3 py-2"
+                placeholder="finance, hr"
+              />
+              <span className="text-xs text-muted-foreground">
+                Leave blank to share with everyone. Separate multiple
+                departments with commas.
+              </span>
+            </label>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Publish announcement
+            </button>
+          </form>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Existing announcements</h2>
+          <div className="space-y-6">
+            {announcements.length === 0 && (
+              <p className="text-muted-foreground text-sm">
+                No announcements created yet.
+              </p>
+            )}
+            {announcements.map((announcement) => (
+              <article
+                key={announcement.id}
+                className="border rounded-lg p-6 space-y-4 bg-card"
+              >
+                <div className="space-y-1">
+                  <h3 className="text-lg font-semibold">
+                    {announcement.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    Category: {announcement.category || 'general'} · Visible to:{' '}
+                    {formatDepartments(announcement.departments)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Updated {new Date(announcement.updatedAt).toLocaleString()}
+                  </p>
+                </div>
+                <form action={updateAnnouncementAction} className="space-y-3">
+                  <input type="hidden" name="id" value={announcement.id} />
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium">Title</span>
+                      <input
+                        name="title"
+                        defaultValue={announcement.title}
+                        className="border rounded-md px-3 py-2"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium">Category</span>
+                      <input
+                        name="category"
+                        defaultValue={announcement.category}
+                        className="border rounded-md px-3 py-2"
+                      />
+                    </label>
+                  </div>
+                  <label className="flex flex-col gap-2">
+                    <span className="text-sm font-medium">Body</span>
+                    <textarea
+                      name="body"
+                      defaultValue={announcement.body}
+                      className="border rounded-md px-3 py-2 min-h-[120px]"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-2">
+                    <span className="text-sm font-medium">Departments</span>
+                    <input
+                      name="departments"
+                      defaultValue={announcement.departments.join(', ')}
+                      className="border rounded-md px-3 py-2"
+                    />
+                  </label>
+                  <div className="flex gap-3">
+                    <button
+                      type="submit"
+                      className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                    >
+                      Save changes
+                    </button>
+                    <button
+                      formAction={deleteAnnouncementAction}
+                      formMethod="post"
+                      className="inline-flex items-center justify-center rounded-md border border-destructive px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </form>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/dashboard/page.tsx
+++ b/src/app/(admin)/dashboard/page.tsx
@@ -1,0 +1,193 @@
+import Link from 'next/link';
+import { requireAdminSession } from '@/lib/auth/admin';
+import {
+  listAnnouncements,
+  listAuditRecords,
+  listLinks,
+} from '@/lib/persistence/resources';
+import { listDocuments } from '@/lib/documents';
+import { listActions, listUsers } from '@/lib/persistence/users';
+
+export default async function AdminDashboardPage() {
+  const session = await requireAdminSession();
+  const [announcements, documents, links, auditLog, users, userActions] =
+    await Promise.all([
+      listAnnouncements(),
+      listDocuments(),
+      listLinks(),
+      listAuditRecords(),
+      listUsers(),
+      listActions(),
+    ]);
+
+  const totalAdmins = users.filter((user) => user.role === 'admin').length;
+  const recentAudit = auditLog.slice(0, 10);
+  const recentUserActions = userActions.slice(0, 10);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-10 space-y-8">
+        <header className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            {session.user?.email ?? 'admin'}
+          </p>
+          <h1 className="text-3xl font-semibold">Admin Dashboard</h1>
+          <p className="text-muted-foreground">
+            Unified management for users, announcements, documents, and links
+            with a consolidated audit trail.
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <DashboardCard
+            title="Users"
+            value={`${users.length}`}
+            description={`${totalAdmins} admins`}
+            href="/users"
+          />
+          <DashboardCard
+            title="Announcements"
+            value={`${announcements.length}`}
+            description="Manage communication"
+            href="/announcements"
+          />
+          <DashboardCard
+            title="Documents"
+            value={`${documents.length}`}
+            description="Versioned files"
+            href="/documents"
+          />
+          <DashboardCard
+            title="Links"
+            value={`${links.length}`}
+            description="Curated resources"
+            href="/links"
+          />
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <div className="border rounded-lg p-6 bg-card space-y-3">
+            <h2 className="text-xl font-semibold">Recent resource activity</h2>
+            <p className="text-sm text-muted-foreground">
+              Track document versions, announcement updates, and link changes.
+            </p>
+            <ul className="space-y-3 text-sm">
+              {recentAudit.length === 0 && (
+                <li className="text-muted-foreground">
+                  No resource activity yet.
+                </li>
+              )}
+              {recentAudit.map((entry) => (
+                <li
+                  key={entry.id}
+                  className="border rounded-md px-3 py-2 bg-background"
+                >
+                  <p className="font-medium">{entry.summary}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {entry.resourceType.toUpperCase()} ·{' '}
+                    {new Date(entry.timestamp).toLocaleString()}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="border rounded-lg p-6 bg-card space-y-3">
+            <h2 className="text-xl font-semibold">Recent user actions</h2>
+            <p className="text-sm text-muted-foreground">
+              Review authentication events and administrative updates.
+            </p>
+            <ul className="space-y-3 text-sm">
+              {recentUserActions.length === 0 && (
+                <li className="text-muted-foreground">No user activity yet.</li>
+              )}
+              {recentUserActions.map((action) => (
+                <li
+                  key={action.id}
+                  className="border rounded-md px-3 py-2 bg-background"
+                >
+                  <p className="font-medium">{action.summary}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {action.type.toUpperCase()} ·{' '}
+                    {new Date(action.timestamp).toLocaleString()}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="border rounded-lg p-6 bg-card space-y-4">
+          <h2 className="text-xl font-semibold">Quick actions</h2>
+          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <QuickAction
+              href="/announcements"
+              title="Post announcement"
+              description="Share news with selected departments."
+            />
+            <QuickAction
+              href="/documents"
+              title="Upload document"
+              description="Add a new version-controlled file."
+            />
+            <QuickAction
+              href="/links"
+              title="Curate link"
+              description="Add shortcuts for teams."
+            />
+            <QuickAction
+              href="/users"
+              title="Manage users"
+              description="Adjust roles and credentials."
+            />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+type DashboardCardProps = {
+  title: string;
+  value: string;
+  description: string;
+  href: string;
+};
+
+function DashboardCard({
+  title,
+  value,
+  description,
+  href,
+}: DashboardCardProps) {
+  return (
+    <Link
+      href={href}
+      className="border rounded-lg p-6 bg-card hover:border-primary transition-colors"
+    >
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">{title}</p>
+        <p className="text-3xl font-semibold">{value}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+    </Link>
+  );
+}
+
+type QuickActionProps = {
+  href: string;
+  title: string;
+  description: string;
+};
+
+function QuickAction({ href, title, description }: QuickActionProps) {
+  return (
+    <Link
+      href={href}
+      className="border rounded-lg p-4 bg-background hover:border-primary transition-colors"
+    >
+      <p className="font-medium">{title}</p>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </Link>
+  );
+}

--- a/src/app/(admin)/documents/page.tsx
+++ b/src/app/(admin)/documents/page.tsx
@@ -1,0 +1,354 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { getAdminActor, requireAdminSession } from '@/lib/auth/admin';
+import { formatDepartments, parseDepartmentInput } from '@/lib/access-control';
+import {
+  appendDocumentVersion,
+  createVersionedDocument,
+  getLatestDocumentVersion,
+  getOrderedVersions,
+  listDocuments,
+  updateDocumentMetadata,
+  deleteDocument,
+} from '@/lib/documents';
+
+const PAGE_PATH = '/documents';
+
+async function createDocumentAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const title = (formData.get('title') as string | null)?.trim() ?? '';
+  const category = (formData.get('category') as string | null)?.trim() ?? '';
+  const departmentsInput = (formData.get('departments') as string | null) ?? '';
+  const summary = (formData.get('summary') as string | null)?.trim() ?? '';
+  const fileName = (formData.get('fileName') as string | null)?.trim() ?? '';
+  const content = (formData.get('content') as string | null)?.trim() ?? '';
+
+  if (!title || !summary || !fileName || !content) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+
+  await createVersionedDocument(
+    {
+      title,
+      category: category || 'general',
+      departments: parseDepartmentInput(departmentsInput),
+      initialVersion: {
+        summary,
+        fileName,
+        content,
+      },
+    },
+    actor
+  );
+
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=created');
+}
+
+async function updateDocumentAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const id = (formData.get('id') as string | null)?.trim();
+  if (!id) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+  const title = (formData.get('title') as string | null)?.trim();
+  const category = (formData.get('category') as string | null)?.trim();
+  const departmentsInput = (formData.get('departments') as string | null) ?? '';
+
+  await updateDocumentMetadata(
+    id,
+    {
+      title: title ?? undefined,
+      category: category ?? undefined,
+      departments: parseDepartmentInput(departmentsInput),
+    },
+    actor
+  );
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=updated');
+}
+
+async function addVersionAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const id = (formData.get('id') as string | null)?.trim();
+  if (!id) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+  const summary = (formData.get('summary') as string | null)?.trim() ?? '';
+  const fileName = (formData.get('fileName') as string | null)?.trim() ?? '';
+  const content = (formData.get('content') as string | null)?.trim() ?? '';
+  if (!summary || !fileName || !content) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+
+  await appendDocumentVersion(
+    id,
+    {
+      summary,
+      fileName,
+      content,
+    },
+    actor
+  );
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=version-added');
+}
+
+async function deleteDocumentAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const id = (formData.get('id') as string | null)?.trim();
+  if (!id) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+  await deleteDocument(id, actor);
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=deleted');
+}
+
+export default async function DocumentsAdminPage() {
+  const session = await requireAdminSession();
+  const documents = await listDocuments();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-10 space-y-8">
+        <header className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            {session.user?.email ?? 'admin'}
+          </p>
+          <h1 className="text-3xl font-semibold">Documents</h1>
+          <p className="text-muted-foreground">
+            Manage versioned documents and control departmental access.
+          </p>
+        </header>
+
+        <section className="bg-card rounded-lg border p-6 space-y-4">
+          <h2 className="text-xl font-semibold">Create Document</h2>
+          <form action={createDocumentAction} className="space-y-4">
+            <div className="grid md:grid-cols-2 gap-4">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Title</span>
+                <input
+                  name="title"
+                  required
+                  className="border rounded-md px-3 py-2"
+                  placeholder="Policy Manual"
+                />
+              </label>
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Category</span>
+                <input
+                  name="category"
+                  className="border rounded-md px-3 py-2"
+                  placeholder="compliance"
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Departments</span>
+              <input
+                name="departments"
+                className="border rounded-md px-3 py-2"
+                placeholder="operations, finance"
+              />
+              <span className="text-xs text-muted-foreground">
+                Leave blank to share with everyone. Separate departments with
+                commas.
+              </span>
+            </label>
+            <div className="grid md:grid-cols-3 gap-4">
+              <label className="flex flex-col gap-2 md:col-span-2">
+                <span className="text-sm font-medium">Version summary</span>
+                <input
+                  name="summary"
+                  required
+                  className="border rounded-md px-3 py-2"
+                  placeholder="Initial release"
+                />
+              </label>
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">File name</span>
+                <input
+                  name="fileName"
+                  required
+                  className="border rounded-md px-3 py-2"
+                  placeholder="policy-v1.txt"
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Content</span>
+              <textarea
+                name="content"
+                required
+                className="border rounded-md px-3 py-2 min-h-[140px]"
+                placeholder="Paste the document contents"
+              />
+            </label>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Save document
+            </button>
+          </form>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Existing documents</h2>
+          <div className="space-y-6">
+            {documents.length === 0 && (
+              <p className="text-muted-foreground text-sm">
+                No documents uploaded yet.
+              </p>
+            )}
+            {documents.map((document) => {
+              const latest = getLatestDocumentVersion(document);
+              const versions = getOrderedVersions(document);
+              const nextVersionNumber = (versions[0]?.version ?? 0) + 1;
+              return (
+                <article
+                  key={document.id}
+                  className="border rounded-lg p-6 space-y-5 bg-card"
+                >
+                  <div className="space-y-1">
+                    <h3 className="text-lg font-semibold">{document.title}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      Category: {document.category || 'general'} · Visible to:{' '}
+                      {formatDepartments(document.departments)}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Updated {new Date(document.updatedAt).toLocaleString()}
+                    </p>
+                    {latest && (
+                      <div className="text-sm text-muted-foreground">
+                        Latest version: v{latest.version} ({latest.fileName}) ·{' '}
+                        <a
+                          href={`/api/documents/${document.id}/download`}
+                          className="text-primary hover:underline"
+                        >
+                          Download
+                        </a>
+                      </div>
+                    )}
+                  </div>
+
+                  <form action={updateDocumentAction} className="space-y-3">
+                    <input type="hidden" name="id" value={document.id} />
+                    <div className="grid md:grid-cols-2 gap-4">
+                      <label className="flex flex-col gap-2">
+                        <span className="text-sm font-medium">Title</span>
+                        <input
+                          name="title"
+                          defaultValue={document.title}
+                          className="border rounded-md px-3 py-2"
+                        />
+                      </label>
+                      <label className="flex flex-col gap-2">
+                        <span className="text-sm font-medium">Category</span>
+                        <input
+                          name="category"
+                          defaultValue={document.category}
+                          className="border rounded-md px-3 py-2"
+                        />
+                      </label>
+                    </div>
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium">Departments</span>
+                      <input
+                        name="departments"
+                        defaultValue={document.departments.join(', ')}
+                        className="border rounded-md px-3 py-2"
+                      />
+                    </label>
+                    <div className="flex gap-3">
+                      <button
+                        type="submit"
+                        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                      >
+                        Save changes
+                      </button>
+                      <button
+                        formAction={deleteDocumentAction}
+                        formMethod="post"
+                        className="inline-flex items-center justify-center rounded-md border border-destructive px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </form>
+
+                  <div className="border rounded-md p-4 space-y-4 bg-background">
+                    <h4 className="font-medium">Add new version</h4>
+                    <form action={addVersionAction} className="space-y-3">
+                      <input type="hidden" name="id" value={document.id} />
+                      <div className="grid md:grid-cols-3 gap-4">
+                        <label className="flex flex-col gap-2 md:col-span-2">
+                          <span className="text-sm font-medium">Summary</span>
+                          <input
+                            name="summary"
+                            className="border rounded-md px-3 py-2"
+                            placeholder="Revision details"
+                            required
+                          />
+                        </label>
+                        <label className="flex flex-col gap-2">
+                          <span className="text-sm font-medium">File name</span>
+                          <input
+                            name="fileName"
+                            className="border rounded-md px-3 py-2"
+                            placeholder={`${document.title}-v${nextVersionNumber}.txt`}
+                            required
+                          />
+                        </label>
+                      </div>
+                      <label className="flex flex-col gap-2">
+                        <span className="text-sm font-medium">Content</span>
+                        <textarea
+                          name="content"
+                          className="border rounded-md px-3 py-2 min-h-[120px]"
+                          placeholder="Paste new version contents"
+                          required
+                        />
+                      </label>
+                      <button
+                        type="submit"
+                        className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                      >
+                        Add version
+                      </button>
+                    </form>
+                  </div>
+
+                  <div className="space-y-2">
+                    <h4 className="font-medium">Version history</h4>
+                    <ul className="space-y-2 text-sm">
+                      {versions.map((version) => (
+                        <li
+                          key={version.id}
+                          className="border rounded-md px-3 py-2 flex flex-col gap-1"
+                        >
+                          <span className="font-medium">
+                            v{version.version} · {version.summary}
+                          </span>
+                          <span className="text-muted-foreground">
+                            {version.fileName} · Updated{' '}
+                            {new Date(version.createdAt).toLocaleString()}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/links/page.tsx
+++ b/src/app/(admin)/links/page.tsx
@@ -1,0 +1,248 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { getAdminActor, requireAdminSession } from '@/lib/auth/admin';
+import { formatDepartments, parseDepartmentInput } from '@/lib/access-control';
+import {
+  createLink,
+  deleteLink,
+  listLinks,
+  updateLink,
+} from '@/lib/persistence/resources';
+
+const PAGE_PATH = '/links';
+
+async function createLinkAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const title = (formData.get('title') as string | null)?.trim() ?? '';
+  const url = (formData.get('url') as string | null)?.trim() ?? '';
+  const category = (formData.get('category') as string | null)?.trim() ?? '';
+  const description = (formData.get('description') as string | null)?.trim();
+  const departmentsInput = (formData.get('departments') as string | null) ?? '';
+
+  if (!title || !url) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+
+  await createLink(
+    {
+      title,
+      url,
+      description: description || undefined,
+      category: category || 'general',
+      departments: parseDepartmentInput(departmentsInput),
+    },
+    actor
+  );
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=created');
+}
+
+async function updateLinkAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const id = (formData.get('id') as string | null)?.trim();
+  if (!id) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+  const title = (formData.get('title') as string | null)?.trim();
+  const url = (formData.get('url') as string | null)?.trim();
+  const category = (formData.get('category') as string | null)?.trim();
+  const description = (formData.get('description') as string | null)?.trim();
+  const departmentsInput = (formData.get('departments') as string | null) ?? '';
+
+  await updateLink(
+    id,
+    {
+      title: title ?? undefined,
+      url: url ?? undefined,
+      category: category ?? undefined,
+      description: description ?? undefined,
+      departments: parseDepartmentInput(departmentsInput),
+    },
+    actor
+  );
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=updated');
+}
+
+async function deleteLinkAction(formData: FormData) {
+  'use server';
+  const actor = await getAdminActor();
+  const id = (formData.get('id') as string | null)?.trim();
+  if (!id) {
+    redirect(PAGE_PATH + '?error=missing');
+  }
+  await deleteLink(id, actor);
+  revalidatePath(PAGE_PATH);
+  redirect(PAGE_PATH + '?status=deleted');
+}
+
+export default async function LinksAdminPage() {
+  const session = await requireAdminSession();
+  const links = await listLinks();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-10 space-y-8">
+        <header className="space-y-2">
+          <p className="text-sm text-muted-foreground">
+            {session.user?.email ?? 'admin'}
+          </p>
+          <h1 className="text-3xl font-semibold">Links</h1>
+          <p className="text-muted-foreground">
+            Curate quick access links with departmental access controls.
+          </p>
+        </header>
+
+        <section className="bg-card rounded-lg border p-6 space-y-4">
+          <h2 className="text-xl font-semibold">Create Link</h2>
+          <form action={createLinkAction} className="space-y-4">
+            <div className="grid md:grid-cols-2 gap-4">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Title</span>
+                <input
+                  name="title"
+                  required
+                  className="border rounded-md px-3 py-2"
+                  placeholder="Intranet"
+                />
+              </label>
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">URL</span>
+                <input
+                  name="url"
+                  required
+                  className="border rounded-md px-3 py-2"
+                  placeholder="https://example.com"
+                />
+              </label>
+            </div>
+            <div className="grid md:grid-cols-2 gap-4">
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Category</span>
+                <input
+                  name="category"
+                  className="border rounded-md px-3 py-2"
+                  placeholder="resources"
+                />
+              </label>
+              <label className="flex flex-col gap-2">
+                <span className="text-sm font-medium">Departments</span>
+                <input
+                  name="departments"
+                  className="border rounded-md px-3 py-2"
+                  placeholder="it, hr"
+                />
+              </label>
+            </div>
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium">Description</span>
+              <textarea
+                name="description"
+                className="border rounded-md px-3 py-2 min-h-[100px]"
+                placeholder="Short summary for portal users"
+              />
+            </label>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Save link
+            </button>
+          </form>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-xl font-semibold">Existing links</h2>
+          <div className="space-y-6">
+            {links.length === 0 && (
+              <p className="text-muted-foreground text-sm">
+                No links created yet.
+              </p>
+            )}
+            {links.map((link) => (
+              <article
+                key={link.id}
+                className="border rounded-lg p-6 space-y-4 bg-card"
+              >
+                <div className="space-y-1">
+                  <h3 className="text-lg font-semibold">{link.title}</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Category: {link.category || 'general'} · Visible to:{' '}
+                    {formatDepartments(link.departments)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Updated {new Date(link.updatedAt).toLocaleString()}
+                  </p>
+                </div>
+                <form action={updateLinkAction} className="space-y-3">
+                  <input type="hidden" name="id" value={link.id} />
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium">Title</span>
+                      <input
+                        name="title"
+                        defaultValue={link.title}
+                        className="border rounded-md px-3 py-2"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium">URL</span>
+                      <input
+                        name="url"
+                        defaultValue={link.url}
+                        className="border rounded-md px-3 py-2"
+                      />
+                    </label>
+                  </div>
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium">Category</span>
+                      <input
+                        name="category"
+                        defaultValue={link.category}
+                        className="border rounded-md px-3 py-2"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-2">
+                      <span className="text-sm font-medium">Departments</span>
+                      <input
+                        name="departments"
+                        defaultValue={link.departments.join(', ')}
+                        className="border rounded-md px-3 py-2"
+                      />
+                    </label>
+                  </div>
+                  <label className="flex flex-col gap-2">
+                    <span className="text-sm font-medium">Description</span>
+                    <textarea
+                      name="description"
+                      defaultValue={link.description}
+                      className="border rounded-md px-3 py-2 min-h-[100px]"
+                    />
+                  </label>
+                  <div className="flex gap-3">
+                    <button
+                      type="submit"
+                      className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+                    >
+                      Save changes
+                    </button>
+                    <button
+                      formAction={deleteLinkAction}
+                      formMethod="post"
+                      className="inline-flex items-center justify-center rounded-md border border-destructive px-4 py-2 text-sm font-medium text-destructive hover:bg-destructive/10"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </form>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/announcements/[id]/page.tsx
+++ b/src/app/announcements/[id]/page.tsx
@@ -1,0 +1,51 @@
+import { getServerSession } from 'next-auth';
+import { notFound } from 'next/navigation';
+import { authOptions } from '@/lib/auth/options';
+import { formatDepartments, hasDepartmentAccess } from '@/lib/access-control';
+import { getAnnouncementById } from '@/lib/persistence/resources';
+
+type Params = {
+  params: { id: string };
+};
+
+export default async function AnnouncementDetailPage({ params }: Params) {
+  const announcement = await getAnnouncementById(params.id);
+  if (!announcement) {
+    notFound();
+  }
+
+  const session = await getServerSession(authOptions);
+  const isAdmin = session?.user?.role === 'admin';
+  const hasAccess = hasDepartmentAccess(
+    session?.user?.department,
+    announcement.departments,
+    {
+      allowAllForAdmins: true,
+      isAdmin,
+    }
+  );
+
+  if (!hasAccess) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-10 space-y-6">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Announcement · {announcement.category || 'general'}
+          </p>
+          <h1 className="text-3xl font-semibold">{announcement.title}</h1>
+          <p className="text-sm text-muted-foreground">
+            Updated {new Date(announcement.updatedAt).toLocaleString()} ·
+            Visible to {formatDepartments(announcement.departments)}
+          </p>
+        </div>
+        <article className="text-base leading-relaxed whitespace-pre-line">
+          {announcement.body}
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/documents/[id]/download/route.ts
+++ b/src/app/api/documents/[id]/download/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/options';
+import { hasDepartmentAccess } from '@/lib/access-control';
+import { getDocumentById, getLatestDocumentVersion } from '@/lib/documents';
+
+export async function GET(
+  _request: Request,
+  context: { params: { id: string } }
+) {
+  const document = await getDocumentById(context.params.id);
+  if (!document) {
+    return NextResponse.json({ error: 'Document not found.' }, { status: 404 });
+  }
+
+  const session = await getServerSession(authOptions);
+  const isAdmin = session?.user?.role === 'admin';
+  const hasAccess = hasDepartmentAccess(
+    session?.user?.department,
+    document.departments,
+    {
+      allowAllForAdmins: true,
+      isAdmin,
+    }
+  );
+
+  if (!hasAccess) {
+    return NextResponse.json(
+      { error: 'You do not have access to this document.' },
+      { status: 403 }
+    );
+  }
+
+  const latest = getLatestDocumentVersion(document);
+  if (!latest) {
+    return NextResponse.json(
+      { error: 'Document has no versions.' },
+      { status: 404 }
+    );
+  }
+
+  const body = Buffer.from(latest.content, 'utf8');
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': `attachment; filename="${encodeURIComponent(latest.fileName)}"`,
+    },
+  });
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/options';
+import { searchResources } from '@/lib/search';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('query') ?? '';
+  const session = await getServerSession(authOptions);
+
+  const results = await searchResources({
+    query,
+    userDepartment: session?.user?.department ?? null,
+    isAdmin: session?.user?.role === 'admin',
+  });
+
+  return NextResponse.json({ results });
+}

--- a/src/app/documents/[id]/page.tsx
+++ b/src/app/documents/[id]/page.tsx
@@ -1,0 +1,94 @@
+import { getServerSession } from 'next-auth';
+import { notFound } from 'next/navigation';
+import { authOptions } from '@/lib/auth/options';
+import { formatDepartments, hasDepartmentAccess } from '@/lib/access-control';
+import {
+  getDocumentById,
+  getLatestDocumentVersion,
+  getOrderedVersions,
+} from '@/lib/documents';
+
+type Params = {
+  params: { id: string };
+};
+
+export default async function DocumentDetailPage({ params }: Params) {
+  const document = await getDocumentById(params.id);
+  if (!document) {
+    notFound();
+  }
+
+  const session = await getServerSession(authOptions);
+  const isAdmin = session?.user?.role === 'admin';
+  const hasAccess = hasDepartmentAccess(
+    session?.user?.department,
+    document.departments,
+    {
+      allowAllForAdmins: true,
+      isAdmin,
+    }
+  );
+
+  if (!hasAccess) {
+    notFound();
+  }
+
+  const latest = getLatestDocumentVersion(document);
+  const versions = getOrderedVersions(document);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto px-4 py-10 space-y-6">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Document · {document.category || 'general'}
+          </p>
+          <h1 className="text-3xl font-semibold">{document.title}</h1>
+          <p className="text-sm text-muted-foreground">
+            Updated {new Date(document.updatedAt).toLocaleString()} · Visible to{' '}
+            {formatDepartments(document.departments)}
+          </p>
+        </div>
+
+        {latest ? (
+          <div className="border rounded-lg p-6 bg-card space-y-3">
+            <h2 className="text-xl font-semibold">Latest version</h2>
+            <p className="text-sm text-muted-foreground">
+              v{latest.version} · {latest.summary}
+            </p>
+            <a
+              href={`/api/documents/${document.id}/download`}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Download {latest.fileName}
+            </a>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            This document has no available versions yet.
+          </p>
+        )}
+
+        <section className="space-y-3">
+          <h2 className="text-xl font-semibold">Version history</h2>
+          <ul className="space-y-2 text-sm">
+            {versions.map((version) => (
+              <li
+                key={version.id}
+                className="border rounded-md px-3 py-2 bg-card"
+              >
+                <p className="font-medium">
+                  v{version.version} · {version.summary}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {version.fileName} · Published{' '}
+                  {new Date(version.createdAt).toLocaleString()}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { AuthButtons } from '@/components/auth/auth-buttons';
+import { SearchPanel } from '@/components/search/search-panel';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -28,7 +29,7 @@ export default async function Home() {
               </a>
               {session?.user?.role === 'admin' && (
                 <a
-                  href="/users"
+                  href="/dashboard"
                   className="text-muted-foreground hover:text-foreground transition-colors"
                 >
                   Admin
@@ -74,7 +75,7 @@ export default async function Home() {
                   {session.user.department || 'N/A'}
                 </p>
                 {session.user.role === 'admin' && (
-                  <a href="/users">
+                  <a href="/dashboard">
                     <Button size="lg">Go to Admin Panel</Button>
                   </a>
                 )}
@@ -88,6 +89,18 @@ export default async function Home() {
               </Button>
             </div>
           )}
+        </div>
+      </section>
+
+      {/* Search Section */}
+      <section className="py-16 px-4 bg-muted/40">
+        <div className="container mx-auto max-w-4xl space-y-4">
+          <h3 className="text-3xl font-bold">Unified Knowledge Search</h3>
+          <p className="text-muted-foreground">
+            Look up announcements, department-specific documents, and curated
+            links in one place.
+          </p>
+          <SearchPanel />
         </div>
       </section>
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -2,6 +2,13 @@
 
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
+
+type CredentialsSignInResult = {
+  error?: string;
+  ok?: boolean;
+  status?: number;
+  url?: string | null;
+};
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import {
@@ -25,11 +32,11 @@ export default function SignInPage() {
     setIsLoading(true);
 
     try {
-      const result = await signIn('credentials', {
+      const result = (await signIn('credentials', {
         email,
         password,
         redirect: false,
-      });
+      })) as CredentialsSignInResult | undefined;
 
       if (result?.error) {
         setError('Invalid email or password');

--- a/src/components/search/search-panel.tsx
+++ b/src/components/search/search-panel.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+
+type SearchResourceType = 'announcement' | 'document' | 'link';
+
+type ApiSearchResult = {
+  id: string;
+  type: SearchResourceType;
+  title: string;
+  highlightedTitle: string;
+  highlightedDescription: string;
+  link: string;
+  category: string;
+  updatedAt: string;
+};
+
+const typeLabel: Record<SearchResourceType, string> = {
+  announcement: 'Announcement',
+  document: 'Document',
+  link: 'Link',
+};
+
+export function SearchPanel() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<ApiSearchResult[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const [hasSearched, setHasSearched] = useState(false);
+
+  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setResults([]);
+      setHasSearched(false);
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(
+          `/api/search?query=${encodeURIComponent(trimmed)}`
+        );
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          setError(payload?.error ?? 'Search failed.');
+          return;
+        }
+        const payload = (await response.json()) as {
+          results: ApiSearchResult[];
+        };
+        setResults(payload.results);
+        setHasSearched(true);
+      } catch (fetchError) {
+        setError(
+          fetchError instanceof Error ? fetchError.message : 'Search failed.'
+        );
+      }
+    });
+  };
+
+  const emptyStateMessage = useMemo(() => {
+    if (!hasSearched) {
+      return 'Try searching for announcements, documents, or curated links.';
+    }
+    if (results.length === 0) {
+      return 'No results found. Adjust your keywords or department filters.';
+    }
+    return null;
+  }, [hasSearched, results.length]);
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSearch} className="flex flex-col md:flex-row gap-3">
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search announcements, documents, links..."
+          className="flex-1 border rounded-md px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          disabled={isPending}
+        >
+          {isPending ? 'Searching…' : 'Search'}
+        </button>
+      </form>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {emptyStateMessage && (
+        <p className="text-sm text-muted-foreground">{emptyStateMessage}</p>
+      )}
+
+      <ul className="space-y-3">
+        {results.map((result) => (
+          <li
+            key={`${result.type}-${result.id}`}
+            className="border rounded-lg p-4 bg-card space-y-1"
+          >
+            <span className="text-xs uppercase tracking-wide text-muted-foreground">
+              {typeLabel[result.type]} · {result.category || 'general'}
+            </span>
+            <a
+              href={result.link}
+              className="block text-lg font-semibold text-primary hover:underline"
+              dangerouslySetInnerHTML={{ __html: result.highlightedTitle }}
+            />
+            <p
+              className="text-sm text-muted-foreground"
+              dangerouslySetInnerHTML={{
+                __html: result.highlightedDescription,
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              Updated {new Date(result.updatedAt).toLocaleString()}
+            </p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/lib/access-control.ts
+++ b/src/lib/access-control.ts
@@ -1,0 +1,59 @@
+import type { ResourceDepartmentScope } from '@/lib/persistence/resources';
+
+export function normalizeDepartments(
+  departments: ResourceDepartmentScope
+): ResourceDepartmentScope {
+  return departments
+    .map((department) => department.trim())
+    .filter((department) => department.length > 0);
+}
+
+export function parseDepartmentInput(input: string): ResourceDepartmentScope {
+  if (!input) {
+    return [];
+  }
+  return normalizeDepartments(input.split(',').map((value) => value.trim()));
+}
+
+export function formatDepartments(
+  departments: ResourceDepartmentScope
+): string {
+  if (!departments.length) {
+    return 'All Departments';
+  }
+  return departments.join(', ');
+}
+
+export function hasDepartmentAccess(
+  userDepartment: string | null | undefined,
+  departments: ResourceDepartmentScope,
+  options: { allowAllForAdmins?: boolean; isAdmin?: boolean } = {}
+): boolean {
+  const normalized = normalizeDepartments(departments);
+  if (!normalized.length) {
+    return true;
+  }
+
+  if (options.allowAllForAdmins && options.isAdmin) {
+    return true;
+  }
+
+  if (!userDepartment) {
+    return normalized.includes('public');
+  }
+
+  const normalizedUser = userDepartment.trim();
+  return normalized.includes(normalizedUser);
+}
+
+export function filterByDepartment<
+  T extends { departments: ResourceDepartmentScope },
+>(
+  items: T[],
+  userDepartment: string | null | undefined,
+  options: { allowAllForAdmins?: boolean; isAdmin?: boolean } = {}
+): T[] {
+  return items.filter((item) =>
+    hasDepartmentAccess(userDepartment, item.departments, options)
+  );
+}

--- a/src/lib/auth/admin.ts
+++ b/src/lib/auth/admin.ts
@@ -1,0 +1,25 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import type { ActorDetails } from '@/lib/persistence/resources';
+import { authOptions } from '@/lib/auth/options';
+
+export async function requireAdminSession() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.role !== 'admin') {
+    redirect('/');
+  }
+  if (!session.user.id) {
+    redirect('/');
+  }
+  return session;
+}
+
+export async function getAdminActor(): Promise<ActorDetails> {
+  const session = await requireAdminSession();
+  return {
+    id: session.user?.id ?? '',
+    email: session.user?.email,
+    name: session.user?.name,
+    department: session.user?.department,
+  };
+}

--- a/src/lib/documents.ts
+++ b/src/lib/documents.ts
@@ -1,0 +1,59 @@
+import {
+  addDocumentVersion,
+  createDocument,
+  updateDocument,
+  type ActorDetails,
+  type AddDocumentVersionInput,
+  type CreateDocumentInput,
+  type DocumentRecord,
+  type DocumentVersionRecord,
+  type UpdateDocumentInput,
+} from '@/lib/persistence/resources';
+
+export {
+  listDocuments,
+  getDocumentById,
+  deleteDocument,
+} from '@/lib/persistence/resources';
+
+export async function createVersionedDocument(
+  input: CreateDocumentInput,
+  actor: ActorDetails
+): Promise<DocumentRecord> {
+  return createDocument(input, actor);
+}
+
+export async function updateDocumentMetadata(
+  id: string,
+  input: UpdateDocumentInput,
+  actor: ActorDetails
+): Promise<DocumentRecord | null> {
+  return updateDocument(id, input, actor);
+}
+
+export async function appendDocumentVersion(
+  id: string,
+  input: AddDocumentVersionInput,
+  actor: ActorDetails
+): Promise<DocumentRecord | null> {
+  return addDocumentVersion(id, input, actor);
+}
+
+export function getLatestDocumentVersion(
+  document: DocumentRecord
+): DocumentVersionRecord | null {
+  if (!document.currentVersionId) {
+    return null;
+  }
+  return (
+    document.versions.find(
+      (version) => version.id === document.currentVersionId
+    ) ?? null
+  );
+}
+
+export function getOrderedVersions(
+  document: DocumentRecord
+): DocumentVersionRecord[] {
+  return [...document.versions].sort((a, b) => b.version - a.version);
+}

--- a/src/lib/persistence/resources.ts
+++ b/src/lib/persistence/resources.ts
@@ -1,0 +1,635 @@
+import { randomUUID } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export type ResourceDepartmentScope = string[];
+
+export type AuditActionType = 'create' | 'update' | 'delete' | 'version';
+export type AuditResourceType = 'announcement' | 'document' | 'link';
+
+export interface ActorDetails {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  department?: string | null;
+}
+
+export interface AuditRecord {
+  id: string;
+  actor: ActorDetails | null;
+  resourceId: string;
+  resourceType: AuditResourceType;
+  action: AuditActionType;
+  summary: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AnnouncementRecord {
+  id: string;
+  title: string;
+  body: string;
+  category: string;
+  departments: ResourceDepartmentScope;
+  authorId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DocumentVersionRecord {
+  id: string;
+  version: number;
+  summary: string;
+  fileName: string;
+  content: string;
+  createdAt: string;
+  createdBy: string;
+}
+
+export interface DocumentRecord {
+  id: string;
+  title: string;
+  category: string;
+  departments: ResourceDepartmentScope;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  currentVersionId: string | null;
+  versions: DocumentVersionRecord[];
+}
+
+export interface LinkRecord {
+  id: string;
+  title: string;
+  url: string;
+  description?: string;
+  category: string;
+  departments: ResourceDepartmentScope;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+}
+
+interface StoreShape {
+  announcements: AnnouncementRecord[];
+  documents: DocumentRecord[];
+  links: LinkRecord[];
+  auditLog: AuditRecord[];
+}
+
+export interface CreateAnnouncementInput {
+  title: string;
+  body: string;
+  category: string;
+  departments: ResourceDepartmentScope;
+}
+
+export interface UpdateAnnouncementInput {
+  title?: string;
+  body?: string;
+  category?: string;
+  departments?: ResourceDepartmentScope;
+}
+
+export interface CreateDocumentInput {
+  title: string;
+  category: string;
+  departments: ResourceDepartmentScope;
+  initialVersion: {
+    summary: string;
+    fileName: string;
+    content: string;
+  };
+}
+
+export interface UpdateDocumentInput {
+  title?: string;
+  category?: string;
+  departments?: ResourceDepartmentScope;
+}
+
+export interface AddDocumentVersionInput {
+  summary: string;
+  fileName: string;
+  content: string;
+}
+
+export interface CreateLinkInput {
+  title: string;
+  url: string;
+  description?: string;
+  category: string;
+  departments: ResourceDepartmentScope;
+}
+
+export interface UpdateLinkInput {
+  title?: string;
+  url?: string;
+  description?: string;
+  category?: string;
+  departments?: ResourceDepartmentScope;
+}
+
+const DATA_DIRECTORY = path.join(process.cwd(), 'data');
+const DATA_FILE = path.join(DATA_DIRECTORY, 'resources.json');
+
+async function ensureStore(): Promise<void> {
+  await fs.mkdir(DATA_DIRECTORY, { recursive: true });
+  try {
+    await fs.access(DATA_FILE);
+  } catch {
+    const initial: StoreShape = {
+      announcements: [],
+      documents: [],
+      links: [],
+      auditLog: [],
+    };
+    await fs.writeFile(DATA_FILE, JSON.stringify(initial, null, 2), 'utf8');
+  }
+}
+
+async function readStore(): Promise<StoreShape> {
+  await ensureStore();
+  const raw = await fs.readFile(DATA_FILE, 'utf8');
+  const parsed = JSON.parse(raw) as Partial<StoreShape>;
+  const announcements = Array.isArray(parsed.announcements)
+    ? parsed.announcements
+    : [];
+  const documents = Array.isArray(parsed.documents) ? parsed.documents : [];
+  const links = Array.isArray(parsed.links) ? parsed.links : [];
+  const auditLog = Array.isArray(parsed.auditLog) ? parsed.auditLog : [];
+
+  return {
+    announcements: announcements.map((record) => ({
+      ...record,
+      departments: Array.isArray(record.departments)
+        ? [...record.departments]
+        : [],
+    })),
+    documents: documents.map((record) => ({
+      ...record,
+      departments: Array.isArray(record.departments)
+        ? [...record.departments]
+        : [],
+      versions: Array.isArray(record.versions)
+        ? record.versions.map((version) => ({
+            ...version,
+          }))
+        : [],
+    })),
+    links: links.map((record) => ({
+      ...record,
+      departments: Array.isArray(record.departments)
+        ? [...record.departments]
+        : [],
+    })),
+    auditLog: auditLog.map((entry) => ({
+      ...entry,
+    })),
+  } satisfies StoreShape;
+}
+
+async function writeStore(store: StoreShape): Promise<void> {
+  await ensureStore();
+  await fs.writeFile(DATA_FILE, JSON.stringify(store, null, 2), 'utf8');
+}
+
+function sortByUpdatedAt<T extends { updatedAt: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+}
+
+function sortAuditLog(records: AuditRecord[]): AuditRecord[] {
+  return [...records].sort((a, b) => {
+    return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+  });
+}
+
+function createAuditRecord(options: {
+  actor: ActorDetails | null;
+  resourceId: string;
+  resourceType: AuditResourceType;
+  action: AuditActionType;
+  summary: string;
+  metadata?: Record<string, unknown>;
+}): AuditRecord {
+  return {
+    id: randomUUID(),
+    actor: options.actor,
+    resourceId: options.resourceId,
+    resourceType: options.resourceType,
+    action: options.action,
+    summary: options.summary,
+    timestamp: new Date().toISOString(),
+    metadata: options.metadata,
+  };
+}
+
+export async function listAnnouncements(): Promise<AnnouncementRecord[]> {
+  const store = await readStore();
+  return sortByUpdatedAt(store.announcements);
+}
+
+export async function listDocuments(): Promise<DocumentRecord[]> {
+  const store = await readStore();
+  return sortByUpdatedAt(store.documents);
+}
+
+export async function listLinks(): Promise<LinkRecord[]> {
+  const store = await readStore();
+  return sortByUpdatedAt(store.links);
+}
+
+export async function listAuditRecords(): Promise<AuditRecord[]> {
+  const store = await readStore();
+  return sortAuditLog(store.auditLog);
+}
+
+export async function getAnnouncementById(
+  id: string
+): Promise<AnnouncementRecord | null> {
+  const store = await readStore();
+  return (
+    store.announcements.find((announcement) => announcement.id === id) ?? null
+  );
+}
+
+export async function getDocumentById(
+  id: string
+): Promise<DocumentRecord | null> {
+  const store = await readStore();
+  return store.documents.find((document) => document.id === id) ?? null;
+}
+
+export async function getLinkById(id: string): Promise<LinkRecord | null> {
+  const store = await readStore();
+  return store.links.find((link) => link.id === id) ?? null;
+}
+
+export async function createAnnouncement(
+  input: CreateAnnouncementInput,
+  actor: ActorDetails
+): Promise<AnnouncementRecord> {
+  const now = new Date().toISOString();
+  const record: AnnouncementRecord = {
+    id: randomUUID(),
+    title: input.title,
+    body: input.body,
+    category: input.category,
+    departments: [...input.departments],
+    authorId: actor.id,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const store = await readStore();
+  store.announcements.push(record);
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: record.id,
+      resourceType: 'announcement',
+      action: 'create',
+      summary: `Created announcement “${record.title}”.`,
+      metadata: { category: record.category, departments: record.departments },
+    })
+  );
+  await writeStore(store);
+  return record;
+}
+
+export async function updateAnnouncement(
+  id: string,
+  input: UpdateAnnouncementInput,
+  actor: ActorDetails
+): Promise<AnnouncementRecord | null> {
+  const store = await readStore();
+  const existingIndex = store.announcements.findIndex(
+    (announcement) => announcement.id === id
+  );
+  if (existingIndex < 0) {
+    return null;
+  }
+
+  const existing = store.announcements[existingIndex];
+  const updated: AnnouncementRecord = {
+    ...existing,
+    title: input.title ?? existing.title,
+    body: input.body ?? existing.body,
+    category: input.category ?? existing.category,
+    departments: input.departments ?? existing.departments,
+    updatedAt: new Date().toISOString(),
+  };
+
+  store.announcements[existingIndex] = updated;
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: updated.id,
+      resourceType: 'announcement',
+      action: 'update',
+      summary: `Updated announcement “${updated.title}”.`,
+      metadata: {
+        category: updated.category,
+        departments: updated.departments,
+      },
+    })
+  );
+  await writeStore(store);
+  return updated;
+}
+
+export async function deleteAnnouncement(
+  id: string,
+  actor: ActorDetails
+): Promise<boolean> {
+  const store = await readStore();
+  const existingIndex = store.announcements.findIndex(
+    (announcement) => announcement.id === id
+  );
+  if (existingIndex < 0) {
+    return false;
+  }
+
+  const [removed] = store.announcements.splice(existingIndex, 1);
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: removed.id,
+      resourceType: 'announcement',
+      action: 'delete',
+      summary: `Deleted announcement “${removed.title}”.`,
+      metadata: { category: removed.category },
+    })
+  );
+  await writeStore(store);
+  return true;
+}
+
+export async function createDocument(
+  input: CreateDocumentInput,
+  actor: ActorDetails
+): Promise<DocumentRecord> {
+  const now = new Date().toISOString();
+  const versionId = randomUUID();
+  const version: DocumentVersionRecord = {
+    id: versionId,
+    version: 1,
+    summary: input.initialVersion.summary,
+    fileName: input.initialVersion.fileName,
+    content: input.initialVersion.content,
+    createdAt: now,
+    createdBy: actor.id,
+  };
+
+  const record: DocumentRecord = {
+    id: randomUUID(),
+    title: input.title,
+    category: input.category,
+    departments: [...input.departments],
+    createdAt: now,
+    updatedAt: now,
+    createdBy: actor.id,
+    currentVersionId: versionId,
+    versions: [version],
+  };
+
+  const store = await readStore();
+  store.documents.push(record);
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: record.id,
+      resourceType: 'document',
+      action: 'create',
+      summary: `Created document “${record.title}”.`,
+      metadata: {
+        category: record.category,
+        departments: record.departments,
+        version: version.version,
+      },
+    })
+  );
+  await writeStore(store);
+  return record;
+}
+
+export async function updateDocument(
+  id: string,
+  input: UpdateDocumentInput,
+  actor: ActorDetails
+): Promise<DocumentRecord | null> {
+  const store = await readStore();
+  const index = store.documents.findIndex((document) => document.id === id);
+  if (index < 0) {
+    return null;
+  }
+
+  const existing = store.documents[index];
+  const updated: DocumentRecord = {
+    ...existing,
+    title: input.title ?? existing.title,
+    category: input.category ?? existing.category,
+    departments: input.departments ?? existing.departments,
+    updatedAt: new Date().toISOString(),
+  };
+
+  store.documents[index] = updated;
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: updated.id,
+      resourceType: 'document',
+      action: 'update',
+      summary: `Updated document “${updated.title}”.`,
+      metadata: {
+        category: updated.category,
+        departments: updated.departments,
+      },
+    })
+  );
+  await writeStore(store);
+  return updated;
+}
+
+export async function deleteDocument(
+  id: string,
+  actor: ActorDetails
+): Promise<boolean> {
+  const store = await readStore();
+  const index = store.documents.findIndex((document) => document.id === id);
+  if (index < 0) {
+    return false;
+  }
+
+  const [removed] = store.documents.splice(index, 1);
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: removed.id,
+      resourceType: 'document',
+      action: 'delete',
+      summary: `Deleted document “${removed.title}”.`,
+      metadata: { category: removed.category },
+    })
+  );
+  await writeStore(store);
+  return true;
+}
+
+export async function addDocumentVersion(
+  id: string,
+  input: AddDocumentVersionInput,
+  actor: ActorDetails
+): Promise<DocumentRecord | null> {
+  const store = await readStore();
+  const index = store.documents.findIndex((document) => document.id === id);
+  if (index < 0) {
+    return null;
+  }
+
+  const existing = store.documents[index];
+  const latestVersion = existing.versions.reduce((max, current) => {
+    return current.version > max ? current.version : max;
+  }, 0);
+
+  const newVersionNumber = latestVersion + 1;
+  const versionId = randomUUID();
+  const now = new Date().toISOString();
+  const version: DocumentVersionRecord = {
+    id: versionId,
+    version: newVersionNumber,
+    summary: input.summary,
+    fileName: input.fileName,
+    content: input.content,
+    createdAt: now,
+    createdBy: actor.id,
+  };
+
+  const updated: DocumentRecord = {
+    ...existing,
+    updatedAt: now,
+    currentVersionId: versionId,
+    versions: [...existing.versions, version],
+  };
+
+  store.documents[index] = updated;
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: updated.id,
+      resourceType: 'document',
+      action: 'version',
+      summary: `Added v${version.version} to document “${updated.title}”.`,
+      metadata: { version: version.version, fileName: version.fileName },
+    })
+  );
+  await writeStore(store);
+  return updated;
+}
+
+export async function createLink(
+  input: CreateLinkInput,
+  actor: ActorDetails
+): Promise<LinkRecord> {
+  const now = new Date().toISOString();
+  const record: LinkRecord = {
+    id: randomUUID(),
+    title: input.title,
+    url: input.url,
+    description: input.description,
+    category: input.category,
+    departments: [...input.departments],
+    createdAt: now,
+    updatedAt: now,
+    createdBy: actor.id,
+  };
+
+  const store = await readStore();
+  store.links.push(record);
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: record.id,
+      resourceType: 'link',
+      action: 'create',
+      summary: `Created link “${record.title}”.`,
+      metadata: { category: record.category, url: record.url },
+    })
+  );
+  await writeStore(store);
+  return record;
+}
+
+export async function updateLink(
+  id: string,
+  input: UpdateLinkInput,
+  actor: ActorDetails
+): Promise<LinkRecord | null> {
+  const store = await readStore();
+  const index = store.links.findIndex((link) => link.id === id);
+  if (index < 0) {
+    return null;
+  }
+
+  const existing = store.links[index];
+  const updated: LinkRecord = {
+    ...existing,
+    title: input.title ?? existing.title,
+    url: input.url ?? existing.url,
+    description: input.description ?? existing.description,
+    category: input.category ?? existing.category,
+    departments: input.departments ?? existing.departments,
+    updatedAt: new Date().toISOString(),
+  };
+
+  store.links[index] = updated;
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: updated.id,
+      resourceType: 'link',
+      action: 'update',
+      summary: `Updated link “${updated.title}”.`,
+      metadata: { category: updated.category, url: updated.url },
+    })
+  );
+  await writeStore(store);
+  return updated;
+}
+
+export async function deleteLink(
+  id: string,
+  actor: ActorDetails
+): Promise<boolean> {
+  const store = await readStore();
+  const index = store.links.findIndex((link) => link.id === id);
+  if (index < 0) {
+    return false;
+  }
+
+  const [removed] = store.links.splice(index, 1);
+  store.auditLog.push(
+    createAuditRecord({
+      actor,
+      resourceId: removed.id,
+      resourceType: 'link',
+      action: 'delete',
+      summary: `Deleted link “${removed.title}”.`,
+      metadata: { category: removed.category },
+    })
+  );
+  await writeStore(store);
+  return true;
+}
+
+export async function clearResourcesStore(): Promise<void> {
+  const initial: StoreShape = {
+    announcements: [],
+    documents: [],
+    links: [],
+    auditLog: [],
+  };
+  await writeStore(initial);
+}

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,160 @@
+import { filterByDepartment } from '@/lib/access-control';
+import {
+  listAnnouncements,
+  listDocuments,
+  listLinks,
+  type AnnouncementRecord,
+  type DocumentRecord,
+  type LinkRecord,
+} from '@/lib/persistence/resources';
+
+export type SearchResourceType = 'announcement' | 'document' | 'link';
+
+export interface SearchIndexEntry {
+  id: string;
+  type: SearchResourceType;
+  title: string;
+  description: string;
+  category: string;
+  departments: string[];
+  updatedAt: string;
+  link: string;
+}
+
+export interface SearchResult extends SearchIndexEntry {
+  highlightedTitle: string;
+  highlightedDescription: string;
+}
+
+function toAnnouncementEntry(record: AnnouncementRecord): SearchIndexEntry {
+  return {
+    id: record.id,
+    type: 'announcement',
+    title: record.title,
+    description: record.body,
+    category: record.category,
+    departments: record.departments,
+    updatedAt: record.updatedAt,
+    link: `/announcements/${record.id}`,
+  };
+}
+
+function toDocumentEntry(record: DocumentRecord): SearchIndexEntry {
+  const latest = record.versions.find(
+    (version) => version.id === record.currentVersionId
+  );
+  const summary = latest?.summary ?? 'Document available';
+  return {
+    id: record.id,
+    type: 'document',
+    title: record.title,
+    description: summary,
+    category: record.category,
+    departments: record.departments,
+    updatedAt: record.updatedAt,
+    link: `/documents/${record.id}`,
+  };
+}
+
+function toLinkEntry(record: LinkRecord): SearchIndexEntry {
+  return {
+    id: record.id,
+    type: 'link',
+    title: record.title,
+    description: record.description ?? record.url,
+    category: record.category,
+    departments: record.departments,
+    updatedAt: record.updatedAt,
+    link: record.url,
+  };
+}
+
+export async function buildSearchIndex(): Promise<SearchIndexEntry[]> {
+  const [announcements, documents, links] = await Promise.all([
+    listAnnouncements(),
+    listDocuments(),
+    listLinks(),
+  ]);
+
+  return [
+    ...announcements.map(toAnnouncementEntry),
+    ...documents.map(toDocumentEntry),
+    ...links.map(toLinkEntry),
+  ];
+}
+
+function sanitizeQuery(query: string): string {
+  return query.trim();
+}
+
+function highlight(value: string, tokens: string[]): string {
+  if (!tokens.length) {
+    return value;
+  }
+
+  let highlighted = value;
+  for (const token of tokens) {
+    if (!token) continue;
+    const regex = new RegExp(`(${escapeRegExp(token)})`, 'gi');
+    highlighted = highlighted.replace(regex, '<mark>$1</mark>');
+  }
+  return highlighted;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function tokenize(query: string): string[] {
+  return Array.from(
+    new Set(
+      query
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+export async function searchResources(options: {
+  query: string;
+  userDepartment?: string | null;
+  isAdmin?: boolean;
+}): Promise<SearchResult[]> {
+  const query = sanitizeQuery(options.query);
+  if (!query) {
+    return [];
+  }
+
+  const tokens = tokenize(query);
+  const index = await buildSearchIndex();
+  const filtered = filterByDepartment(index, options.userDepartment ?? null, {
+    allowAllForAdmins: true,
+    isAdmin: options.isAdmin ?? false,
+  });
+
+  const matched = filtered
+    .map((entry) => {
+      const haystack =
+        `${entry.title} ${entry.description} ${entry.category}`.toLowerCase();
+      const isMatch = tokens.every((token) =>
+        haystack.includes(token.toLowerCase())
+      );
+      if (!isMatch) {
+        return null;
+      }
+
+      return {
+        ...entry,
+        highlightedTitle: highlight(entry.title, tokens),
+        highlightedDescription: highlight(entry.description, tokens),
+      } satisfies SearchResult;
+    })
+    .filter((value): value is SearchResult => value !== null)
+    .sort(
+      (a, b) =>
+        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    );
+
+  return matched;
+}


### PR DESCRIPTION
## Summary
- implement file-backed persistence for announcements, documents with versioning, links, and audit logs alongside department-aware helpers
- build admin dashboards for managing announcements, documents, links, and provide detail views plus download endpoint guarded by department access
- add unified search API and UI that highlights results across announcements, documents, and links with department-aware filtering

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d5d3f9c3e8832c9c3e975c16123ec4